### PR TITLE
feature: nginx conf の更新、docker-compose.yml の更新

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ services:
   backend:
     build:
       context: ./backend
-    ports:
-      - "8080:8080"
+    network_mode: service:db
     depends_on:
       - db
 
@@ -11,12 +10,15 @@ services:
     build:
       context: ./frontend
     ports:
-      - "5173:80"
+      - "5173:8080"
+    environment:
+      - API_URL=http://db:8080
 
   db:
     image: postgres:18.1-alpine
     ports:
       - "5432:5432"
+      - "8080:8080"
     environment:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,23 @@ FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Cloud Run defaults to port 8080. Configure Nginx to listen on 8080.
-RUN sed -i 's/listen       80;/listen       8080;/g' /etc/nginx/conf.d/default.conf
+ENV API_URL="http://localhost:8080"
+
+RUN mkdir -p /etc/nginx/templates/ && \
+    printf 'server {\n\
+    listen 8080;\n\
+    server_name localhost;\n\
+    \n\
+    location / {\n\
+        root /usr/share/nginx/html;\n\
+        index index.html index.htm;\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+    \n\
+    location /api {\n\
+        proxy_pass ${API_URL}/api;\n\
+    }\n\
+}' > /etc/nginx/templates/default.conf.template
 
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 概要
- vite.config の proxy はビルドすると無視されるので、nginx に手動で設定を記載
- あと、docker compose がちゃんと動かなかったので修正

## 特に見てほしいポイント
これを cloud run にデプロイして動くかはわからない。

## 動作確認した内容
`make up` してから `http://localhost:5173` に接続して、一通りの操作ができることを確認した

## その他
バグ修正してやった感出してすみません。反省しています。もっと時間を切り詰めて取り組んでいきます。すみません、絶対に1/28までに終わらせます。