### PR TITLE
refactor(frontend): AssetTableをデジタル庁デザインシステム準拠に変更

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -16,7 +15,6 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
 	appEnv := os.Getenv("APP_ENV")
 
 	var dsn string
@@ -42,7 +40,7 @@ func main() {
 		log.Fatalf("failed to migrate database: %v", err)
 	}
 
-	userRepo := repository.NewUserRepository(ctx, db)
+	userRepo := repository.NewUserRepository(db)
 	userService := service.NewUserService(userRepo)
 	h := handler.NewHandler(userService)
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	appEnv := os.Getenv("APP_ENV")
 
 	var dsn string
@@ -40,7 +42,7 @@ func main() {
 		log.Fatalf("failed to migrate database: %v", err)
 	}
 
-	userRepo := repository.NewUserRepository(db)
+	userRepo := repository.NewUserRepository(ctx, db)
 	userService := service.NewUserService(userRepo)
 	h := handler.NewHandler(userService)
 

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -17,7 +17,7 @@ func NewHandler(userService service.UserService) *Handler {
 }
 
 func (h *Handler) GetAllUsers(ctx *gin.Context) {
-	users, err := h.UserService.FindAll()
+	users, err := h.UserService.FindAll(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
@@ -33,7 +33,7 @@ func (h *Handler) CreateUser(ctx *gin.Context) {
 		return
 	}
 
-	if err := h.UserService.Create(&user); err != nil {
+	if err := h.UserService.Create(ctx, &user); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
 		return
 	}

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -40,3 +40,18 @@ func (h *Handler) CreateUser(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusCreated, user)
 }
+
+func (h *Handler) UpdateRecord(ctx *gin.Context) {
+	var user model.User
+	if err := ctx.ShouldBindJSON(&user); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.UserService.Create(ctx, &user); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update user record"})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, user)
+}

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -16,27 +16,27 @@ func NewHandler(userService service.UserService) *Handler {
 	return &Handler{UserService: userService}
 }
 
-func (h *Handler) GetAllUsers(c *gin.Context) {
+func (h *Handler) GetAllUsers(ctx *gin.Context) {
 	users, err := h.UserService.FindAll()
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
 	}
 
-	c.JSON(http.StatusOK, users)
+	ctx.JSON(http.StatusOK, users)
 }
 
-func (h *Handler) CreateUser(c *gin.Context) {
+func (h *Handler) CreateUser(ctx *gin.Context) {
 	var user model.User
-	if err := c.ShouldBindJSON(&user); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	if err := ctx.ShouldBindJSON(&user); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
 	if err := h.UserService.Create(&user); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
 		return
 	}
 
-	c.JSON(http.StatusCreated, user)
+	ctx.JSON(http.StatusCreated, user)
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -25,11 +25,10 @@ func NewUserRepository(ctx context.Context, db *gorm.DB) UserRepository {
 }
 
 func (r *userRepository) FindAll() ([]model.User, error) {
-	var users []model.User
-	result := r.db.Find(&users)
-	return users, result.Error
+	users, err := gorm.G[model.User](r.db).Find(r.ctx)
+	return users, err
 }
 
 func (r *userRepository) Create(user *model.User) error {
-	return r.db.Create(user).Error
+	return gorm.G[model.User](r.db).Create(r.ctx, user)
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -8,27 +8,23 @@ import (
 )
 
 type UserRepository interface {
-	FindAll() ([]model.User, error)
-	Create(user *model.User) error
+	FindAll(ctx context.Context) ([]model.User, error)
+	Create(ctx context.Context, user *model.User) error
 }
 
 type userRepository struct {
-	ctx context.Context
-	db  *gorm.DB
+	db *gorm.DB
 }
 
-func NewUserRepository(ctx context.Context, db *gorm.DB) UserRepository {
-	return &userRepository{
-		ctx: ctx,
-		db:  db,
-	}
+func NewUserRepository(db *gorm.DB) UserRepository {
+	return &userRepository{db: db}
 }
 
-func (r *userRepository) FindAll() ([]model.User, error) {
-	users, err := gorm.G[model.User](r.db).Find(r.ctx)
+func (r *userRepository) FindAll(ctx context.Context) ([]model.User, error) {
+	users, err := gorm.G[model.User](r.db).Find(ctx)
 	return users, err
 }
 
-func (r *userRepository) Create(user *model.User) error {
-	return gorm.G[model.User](r.db).Create(r.ctx, user)
+func (r *userRepository) Create(ctx context.Context, user *model.User) error {
+	return gorm.G[model.User](r.db).Create(ctx, user)
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -10,6 +10,7 @@ import (
 type UserRepository interface {
 	FindAll(ctx context.Context) ([]model.User, error)
 	Create(ctx context.Context, user *model.User) error
+	UpdateRecord(ctx context.Context, newUser model.User) error
 }
 
 type userRepository struct {

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/AZ-Tokyo/AZ-Tokyo/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -11,11 +13,15 @@ type UserRepository interface {
 }
 
 type userRepository struct {
-	db *gorm.DB
+	ctx context.Context
+	db  *gorm.DB
 }
 
-func NewUserRepository(db *gorm.DB) UserRepository {
-	return &userRepository{db: db}
+func NewUserRepository(ctx context.Context, db *gorm.DB) UserRepository {
+	return &userRepository{
+		ctx: ctx,
+		db:  db,
+	}
 }
 
 func (r *userRepository) FindAll() ([]model.User, error) {

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -28,3 +28,11 @@ func (r *userRepository) FindAll(ctx context.Context) ([]model.User, error) {
 func (r *userRepository) Create(ctx context.Context, user *model.User) error {
 	return gorm.G[model.User](r.db).Create(ctx, user)
 }
+
+func (r *userRepository) UpdateRecord(ctx context.Context, newUser model.User) error {
+	_, err := gorm.G[model.User](r.db).Where("id = ?", newUser.ID).Updates(ctx, newUser)
+	if err != nil {
+		err = r.Create(ctx, &newUser)
+	}
+	return err
+}

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -111,7 +111,7 @@ func (s *UserRepositoryTestSuite) TestUpdateRecord_Success() {
 	user2.Name = "New 42Tokyo"
 	user2.DeathDate = &deathDate2
 
-	// Update user1 with user1
+	// Update user1 record with user2 data
 	err = s.repo.UpdateRecord(ctx, user2)
 	s.NoError(err)
 

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -107,7 +107,8 @@ func (s *UserRepositoryTestSuite) TestUpdateRecord_Success() {
 	/* Test Update user1 record */
 	// Copy user1 to user2
 	deathDate2 := time.Date(2019, time.April, 7, 21, 48, 00, 00, jst)
-	user2 := resultUser1
+	user2 := *user1
+	user2.ID = user1.ID
 	user2.Name = "New 42Tokyo"
 	user2.DeathDate = &deathDate2
 

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -17,7 +17,6 @@ type UserRepositoryTestSuite struct {
 }
 
 func (s *UserRepositoryTestSuite) SetupTest() {
-	ctx := context.Background()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	s.NoError(err)
 	if err := db.AutoMigrate(&model.User{}); err != nil {
@@ -25,14 +24,15 @@ func (s *UserRepositoryTestSuite) SetupTest() {
 	}
 
 	s.db = db
-	s.repo = NewUserRepository(ctx, db)
+	s.repo = NewUserRepository(db)
 }
 
 func (s *UserRepositoryTestSuite) TestFindAll_Success() {
+	ctx := context.Background()
 	testUser := model.User{Name: "Test User"}
-	s.db.Create(&testUser)
 
-	users, err := s.repo.FindAll()
+	s.db.Create(&testUser)
+	users, err := s.repo.FindAll(ctx)
 
 	s.NoError(err)
 	s.Len(users, 1)
@@ -40,16 +40,18 @@ func (s *UserRepositoryTestSuite) TestFindAll_Success() {
 }
 
 func (s *UserRepositoryTestSuite) TestFindAll_Empty() {
-	users, err := s.repo.FindAll()
+	ctx := context.Background()
+	users, err := s.repo.FindAll(ctx)
 
 	s.NoError(err)
 	s.Len(users, 0)
 }
 
 func (s *UserRepositoryTestSuite) TestCreate_Success() {
+	ctx := context.Background()
 	user := &model.User{Name: "Yamada"}
 
-	err := s.repo.Create(user)
+	err := s.repo.Create(ctx, user)
 
 	s.NoError(err)
 	s.NotZero(user.ID)
@@ -61,10 +63,11 @@ func (s *UserRepositoryTestSuite) TestCreate_Success() {
 }
 
 func (s *UserRepositoryTestSuite) TestCreate_Error() {
+	ctx := context.Background()
 	s.NoError(s.db.Migrator().DropTable(&model.User{}))
 
 	user := &model.User{Name: "Error User"}
-	err := s.repo.Create(user)
+	err := s.repo.Create(ctx, user)
 
 	s.Error(err)
 }

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AZ-Tokyo/AZ-Tokyo/backend/internal/model"
@@ -16,6 +17,7 @@ type UserRepositoryTestSuite struct {
 }
 
 func (s *UserRepositoryTestSuite) SetupTest() {
+	ctx := context.Background()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	s.NoError(err)
 	if err := db.AutoMigrate(&model.User{}); err != nil {
@@ -23,7 +25,7 @@ func (s *UserRepositoryTestSuite) SetupTest() {
 	}
 
 	s.db = db
-	s.repo = NewUserRepository(db)
+	s.repo = NewUserRepository(ctx, db)
 }
 
 func (s *UserRepositoryTestSuite) TestFindAll_Success() {

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/AZ-Tokyo/AZ-Tokyo/backend/internal/model"
 	"github.com/stretchr/testify/suite"
@@ -19,6 +20,7 @@ type UserRepositoryTestSuite struct {
 func (s *UserRepositoryTestSuite) SetupTest() {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	s.NoError(err)
+
 	if err := db.AutoMigrate(&model.User{}); err != nil {
 		panic("Failed to migrate database: " + err.Error())
 	}
@@ -69,6 +71,77 @@ func (s *UserRepositoryTestSuite) TestCreate_Error() {
 	user := &model.User{Name: "Error User"}
 	err := s.repo.Create(ctx, user)
 
+	s.Error(err)
+}
+
+func (s *UserRepositoryTestSuite) TestUpdateRecord_Success() {
+	ctx := context.Background()
+	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
+
+	/* Prepare user1 record */
+	// initialize user1 object
+	birthDate1 := time.Date(1960, time.September, 8, 15, 23, 00, 00, jst)
+	deathDate1 := time.Date(2025, time.January, 26, 12, 00, 00, 00, jst)
+	lastAddress1 := "神奈川県横浜市"
+	user1 := &model.User{
+		Name:          "Old 42Tokyo",
+		BirthDate:     &birthDate1,
+		DeathDate:     &deathDate1,
+		LegalDomicile: &lastAddress1,
+		LastAddress:   &lastAddress1,
+		Remarks:       nil,
+	}
+
+	// Create user1 record in db
+	err := s.repo.Create(ctx, user1)
+	s.NoError(err)
+
+	// Assert user1 and resultUser1
+	resultUser1, err1 := gorm.G[model.User](s.db).Where("name = ?", user1.Name).First(ctx)
+	s.NoError(err1)
+	s.Equal(user1.Name, resultUser1.Name)
+	s.True(user1.BirthDate.Equal(*resultUser1.BirthDate))
+	s.True(user1.DeathDate.Equal(*resultUser1.DeathDate))
+	s.Equal(user1.LegalDomicile, resultUser1.LegalDomicile)
+	s.Equal(user1.LastAddress, resultUser1.LastAddress)
+
+	/* Test Update user1 record */
+	// Copy user1 to user2
+	deathDate2 := time.Date(2019, time.April, 7, 21, 48, 00, 00, jst)
+	user2 := resultUser1
+	user2.Name = "New 42Tokyo"
+	user2.DeathDate = &deathDate2
+
+	// Update user1 with user1
+	err = s.repo.UpdateRecord(ctx, user2)
+	s.NoError(err)
+
+	// Assert user2 and resultUser2
+	resultUser2, err2 := gorm.G[model.User](s.db).Where("name = ?", user2.Name).First(ctx)
+	s.NoError(err2)
+	s.Equal(user2.Name, resultUser2.Name)
+	s.True(user2.BirthDate.Equal(*resultUser2.BirthDate))
+	s.True(user2.DeathDate.Equal(*resultUser2.DeathDate))
+	s.Equal(user2.LegalDomicile, resultUser2.LegalDomicile)
+	s.Equal(user2.LastAddress, resultUser2.LastAddress)
+
+	// Assert resultUser1 and resultUser2
+	s.NotEqual(resultUser1, resultUser2)
+	s.NotEqual(resultUser1.Name, resultUser2.Name)
+	s.Equal(resultUser1.BirthDate, resultUser2.BirthDate)
+	s.NotEqual(resultUser1.DeathDate, resultUser2.DeathDate)
+	s.Equal(resultUser1.LegalDomicile, resultUser2.LegalDomicile)
+	s.Equal(resultUser1.LastAddress, resultUser2.LastAddress)
+	s.Equal(resultUser1.Remarks, resultUser2.Remarks)
+}
+
+func (s *UserRepositoryTestSuite) TestUpdateRecord_Error() {
+	ctx := context.Background()
+	s.NoError(s.db.Migrator().DropTable(&model.User{}))
+
+	user := model.User{Name: "New 42Tokyo"}
+
+	err := s.repo.UpdateRecord(ctx, user)
 	s.Error(err)
 }
 

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -58,10 +58,9 @@ func (s *UserRepositoryTestSuite) TestCreate_Success() {
 	s.NoError(err)
 	s.NotZero(user.ID)
 
-	var dbUser model.User
-	result := s.db.First(&dbUser, user.ID)
-	s.NoError(result.Error)
-	s.Equal("Yamada", dbUser.Name)
+	result, err := gorm.G[model.User](s.db).Where("id = ?", user.ID).First(ctx)
+	s.NoError(err)
+	s.Equal("Yamada", result.Name)
 }
 
 func (s *UserRepositoryTestSuite) TestCreate_Error() {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -7,7 +7,8 @@ import (
 
 func Setup(h *handler.Handler) *gin.Engine {
 	router := gin.Default()
-	router.GET("/api/users", h.GetAllUsers)
-	router.POST("/api/users", h.CreateUser)
+	router.GET("/api/users/find", h.GetAllUsers)
+	router.POST("/api/users/create", h.CreateUser)
+	router.POST("/api/user/update", h.UpdateRecord)
 	return router
 }

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -10,6 +10,7 @@ import (
 type UserService interface {
 	FindAll(ctx context.Context) ([]model.User, error)
 	Create(ctx context.Context, user *model.User) error
+	UpdateRecord(ctx context.Context, newUser model.User) error
 }
 
 type userService struct {
@@ -26,4 +27,8 @@ func (s *userService) FindAll(ctx context.Context) ([]model.User, error) {
 
 func (s *userService) Create(ctx context.Context, user *model.User) error {
 	return s.repo.Create(ctx, user)
+}
+
+func (s *userService) UpdateRecord(ctx context.Context, user model.User) error {
+	return s.repo.UpdateRecord(ctx, user)
 }

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -1,13 +1,15 @@
 package service
 
 import (
+	"context"
+
 	"github.com/AZ-Tokyo/AZ-Tokyo/backend/internal/model"
 	"github.com/AZ-Tokyo/AZ-Tokyo/backend/internal/repository"
 )
 
 type UserService interface {
-	FindAll() ([]model.User, error)
-	Create(user *model.User) error
+	FindAll(ctx context.Context) ([]model.User, error)
+	Create(ctx context.Context, user *model.User) error
 }
 
 type userService struct {
@@ -18,10 +20,10 @@ func NewUserService(repo repository.UserRepository) UserService {
 	return &userService{repo: repo}
 }
 
-func (s *userService) FindAll() ([]model.User, error) {
-	return s.repo.FindAll()
+func (s *userService) FindAll(ctx context.Context) ([]model.User, error) {
+	return s.repo.FindAll(ctx)
 }
 
-func (s *userService) Create(user *model.User) error {
-	return s.repo.Create(user)
+func (s *userService) Create(ctx context.Context, user *model.User) error {
+	return s.repo.Create(ctx, user)
 }

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -13,26 +14,28 @@ type MockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) FindAll() ([]model.User, error) {
-	args := m.Called()
+func (m *MockUserRepository) FindAll(ctx context.Context) ([]model.User, error) {
+	args := m.Called(ctx)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]model.User), args.Error(1)
 }
 
-func (m *MockUserRepository) Create(user *model.User) error {
-	args := m.Called(user)
+func (m *MockUserRepository) Create(ctx context.Context, user *model.User) error {
+	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
 func TestFindAll_Success(t *testing.T) {
+	ctx := context.Background()
+
 	mockRepo := new(MockUserRepository)
 	users := []model.User{{Name: "Test User"}}
-	mockRepo.On("FindAll").Return(users, nil)
+	mockRepo.On("FindAll", mock.Anything).Return(users, nil)
 
 	service := NewUserService(mockRepo)
-	result, err := service.FindAll()
+	result, err := service.FindAll(ctx)
 
 	assert.NoError(t, err)
 	assert.Equal(t, users, result)
@@ -40,11 +43,13 @@ func TestFindAll_Success(t *testing.T) {
 }
 
 func TestFindAll_Error(t *testing.T) {
+	ctx := context.Background()
+
 	mockRepo := new(MockUserRepository)
-	mockRepo.On("FindAll").Return(nil, errors.New("db error"))
+	mockRepo.On("FindAll", mock.Anything).Return(nil, errors.New("db error"))
 
 	service := NewUserService(mockRepo)
-	result, err := service.FindAll()
+	result, err := service.FindAll(ctx)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -52,24 +57,28 @@ func TestFindAll_Error(t *testing.T) {
 }
 
 func TestCreate_Success(t *testing.T) {
+	ctx := context.Background()
+
 	mockRepo := new(MockUserRepository)
 	user := &model.User{Name: "New User"}
-	mockRepo.On("Create", user).Return(nil)
+	mockRepo.On("Create", mock.Anything, user).Return(nil)
 
 	service := NewUserService(mockRepo)
-	err := service.Create(user)
+	err := service.Create(ctx, user)
 
 	assert.NoError(t, err)
 	mockRepo.AssertExpectations(t)
 }
 
 func TestCreate_Error(t *testing.T) {
+	ctx := context.Background()
+
 	mockRepo := new(MockUserRepository)
 	user := &model.User{Name: "New User"}
-	mockRepo.On("Create", user).Return(errors.New("db error"))
+	mockRepo.On("Create", mock.Anything, user).Return(errors.New("db error"))
 
 	service := NewUserService(mockRepo)
-	err := service.Create(user)
+	err := service.Create(ctx, user)
 
 	assert.Error(t, err)
 	mockRepo.AssertExpectations(t)

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -115,7 +115,7 @@ func TestUpdateRecord_Error(t *testing.T) {
 
 	mockRepo := new(MockUserRepository)
 	user := model.User{Name: "New 42Tokyo"}
-	mockRepo.On("UpdateRecord", mock.Anything, user).Return(errors.New("Not found record"))
+	mockRepo.On("UpdateRecord", mock.Anything, user).Return(errors.New("Record of user not found"))
 
 	service := NewUserService(mockRepo)
 	err := service.UpdateRecord(ctx, user)

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -27,6 +27,11 @@ func (m *MockUserRepository) Create(ctx context.Context, user *model.User) error
 	return args.Error(0)
 }
 
+func (m *MockUserRepository) UpdateRecord(ctx context.Context, user model.User) error {
+	args := m.Called(ctx, user)
+	return args.Error(0)
+}
+
 func TestFindAll_Success(t *testing.T) {
 	ctx := context.Background()
 
@@ -79,6 +84,41 @@ func TestCreate_Error(t *testing.T) {
 
 	service := NewUserService(mockRepo)
 	err := service.Create(ctx, user)
+
+	assert.Error(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestUpdateRecord_Success(t *testing.T) {
+	ctx := context.Background()
+
+	mockRepo := new(MockUserRepository)
+	user1 := &model.User{Name: "Old 42Tokyo"}
+	user2 := *user1
+	user2.Name = "New 42Tokyo"
+
+	mockRepo.On("Create", mock.Anything, user1).Return(nil)
+	mockRepo.On("UpdateRecord", mock.Anything, user2).Return(nil)
+
+	service := NewUserService(mockRepo)
+	err1 := service.Create(ctx, user1)
+	err2 := service.UpdateRecord(ctx, user2)
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, *user1, user2)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestUpdateRecord_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockRepo := new(MockUserRepository)
+	user := model.User{Name: "New 42Tokyo"}
+	mockRepo.On("UpdateRecord", mock.Anything, user).Return(errors.New("Not found record"))
+
+	service := NewUserService(mockRepo)
+	err := service.UpdateRecord(ctx, user)
 
 	assert.Error(t, err)
 	mockRepo.AssertExpectations(t)


### PR DESCRIPTION
## 概要
AssetTableコンポーネントのスタイリングをデジタル庁デザインシステムのガイドラインに準拠させた。

## 変更内容
- テーブルのスタイルを公式Tailwind CSSクラスに置き換え
  - `bg-solid-gray-100`, `border-solid-gray-420` 等のデザイントークン使用
  - `text-std-16N-170` (公式タイポグラフィ)
- URLリンクをデジタル庁公式Linkコンポーネントに変更
- 大文字変換 (uppercase) を削除

## テスト
- 全29テスト通過

closes #169